### PR TITLE
Use default formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-imports_granularity = "Module"
-struct_field_align_threshold = 20

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -22,7 +22,7 @@ const MAX_TOKEN_LENGTH: usize = 128 * 1024;
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Key {
     #[serde(rename(deserialize = "keyName"))]
-    pub name:  String,
+    pub name: String,
     pub value: String,
 }
 
@@ -46,7 +46,7 @@ impl TryFrom<&str> for Key {
     fn try_from(s: &str) -> Result<Self> {
         if let [name, value] = s.splitn(2, ':').collect::<Vec<&str>>()[..] {
             Ok(Key {
-                name:  name.to_string(),
+                name: name.to_string(),
                 value: value.to_string(),
             })
         } else {
@@ -94,7 +94,7 @@ impl AuthCallback for Key {
 #[derive(Clone, Debug)]
 pub struct Auth {
     client: rest::Client,
-    opts:   ClientOptions,
+    opts: ClientOptions,
 }
 
 impl Auth {
@@ -125,10 +125,10 @@ impl Auth {
             builder = builder.auth_callback(callback.clone());
         } else if let Some(ref url) = self.opts.auth_url {
             builder = builder.auth_url(AuthUrl {
-                url:     url.clone(),
-                method:  self.opts.auth_method.clone(),
+                url: url.clone(),
+                method: self.opts.auth_method.clone(),
                 headers: self.opts.auth_headers.clone(),
-                params:  self.opts.auth_params.clone(),
+                params: self.opts.auth_params.clone(),
             });
         } else if let Some(ref key) = self.opts.key {
             builder = builder.key(key.clone());
@@ -241,14 +241,14 @@ impl Auth {
 
 /// A builder to create a signed TokenRequest.
 pub struct CreateTokenRequestBuilder {
-    key:    Option<Key>,
+    key: Option<Key>,
     params: TokenParams,
 }
 
 impl CreateTokenRequestBuilder {
     fn new() -> Self {
         Self {
-            key:    None,
+            key: None,
             params: TokenParams::default(),
         }
     }
@@ -295,9 +295,9 @@ impl CreateTokenRequestBuilder {
 
 /// A builder to request a token.
 pub struct RequestTokenBuilder {
-    client:   rest::Client,
+    client: rest::Client,
     callback: Option<Box<dyn AuthCallback>>,
-    params:   TokenParams,
+    params: TokenParams,
 }
 
 impl RequestTokenBuilder {
@@ -433,7 +433,7 @@ impl RequestTokenBuilder {
 #[derive(Clone, Debug)]
 pub struct AuthUrlCallback {
     client: rest::Client,
-    url:    AuthUrl,
+    url: AuthUrl,
 }
 
 impl AuthUrlCallback {
@@ -479,10 +479,10 @@ impl AuthCallback for AuthUrlCallback {
 /// A URL to request a token from, along with the HTTP method, headers, and
 /// query params to include in the request.
 pub struct AuthUrl {
-    pub url:     reqwest::Url,
-    pub method:  http::Method,
+    pub url: reqwest::Url,
+    pub method: http::Method,
     pub headers: Option<http::HeaderMap>,
-    pub params:  Option<http::UrlQuery>,
+    pub params: Option<http::UrlQuery>,
 }
 
 impl AuthUrl {
@@ -518,10 +518,10 @@ impl From<reqwest::Url> for AuthUrl {
 #[derive(Clone, Debug, Default)]
 pub struct TokenParams {
     pub capability: Option<String>,
-    pub client_id:  Option<String>,
-    pub nonce:      Option<String>,
-    pub timestamp:  Option<DateTime<Utc>>,
-    pub ttl:        Option<i64>,
+    pub client_id: Option<String>,
+    pub nonce: Option<String>,
+    pub timestamp: Option<DateTime<Utc>>,
+    pub ttl: Option<i64>,
 }
 
 impl TokenParams {
@@ -538,13 +538,13 @@ impl TokenParams {
         }
 
         let mut req = TokenRequest {
-            key_name:   key.name.clone(),
-            timestamp:  self.timestamp.unwrap_or_else(Utc::now),
+            key_name: key.name.clone(),
+            timestamp: self.timestamp.unwrap_or_else(Utc::now),
             capability: self.capability,
-            client_id:  self.client_id,
-            nonce:      self.nonce.unwrap_or_else(Auth::generate_nonce),
-            ttl:        self.ttl,
-            mac:        None,
+            client_id: self.client_id,
+            nonce: self.nonce.unwrap_or_else(Auth::generate_nonce),
+            ttl: self.ttl,
+            mac: None,
         };
 
         req.mac = Some(Auth::compute_mac(key, &req)?);
@@ -559,19 +559,19 @@ impl TokenParams {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenRequest {
-    pub key_name:   String,
+    pub key_name: String,
     #[serde(with = "chrono::serde::ts_milliseconds")]
-    pub timestamp:  DateTime<Utc>,
+    pub timestamp: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capability: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_id:  Option<String>,
+    pub client_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mac:        Option<String>,
+    pub mac: Option<String>,
     #[serde(skip_serializing_if = "String::is_empty")]
-    pub nonce:      String,
+    pub nonce: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ttl:        Option<i64>,
+    pub ttl: Option<i64>,
 }
 
 /// The token details returned in a successful response from the [REST
@@ -581,17 +581,17 @@ pub struct TokenRequest {
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenDetails {
-    pub token:      String,
+    pub token: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "chrono::serde::ts_milliseconds_option")]
-    pub expires:    Option<DateTime<Utc>>,
+    pub expires: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "chrono::serde::ts_milliseconds_option")]
-    pub issued:     Option<DateTime<Utc>>,
+    pub issued: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capability: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_id:  Option<String>,
+    pub client_id: Option<String>,
 }
 
 impl From<String> for TokenDetails {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -177,8 +177,8 @@ mod tests {
 
     #[derive(Deserialize)]
     struct CryptoData {
-        key:   String,
-        iv:    String,
+        key: String,
+        iv: String,
         items: Vec<CryptoFixture>,
     }
 
@@ -214,7 +214,7 @@ mod tests {
 
     #[derive(Deserialize)]
     struct CryptoFixture {
-        encoded:   json::Value,
+        encoded: json::Value,
         encrypted: json::Value,
     }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -22,7 +22,7 @@ pub type UrlQuery = Box<[(String, String)]>;
 /// [Ably REST API]: https://ably.com/documentation/rest-api
 pub struct RequestBuilder {
     client: rest::Client,
-    inner:  Result<reqwest::RequestBuilder>,
+    inner: Result<reqwest::RequestBuilder>,
     format: rest::Format,
 }
 
@@ -125,14 +125,14 @@ impl RequestBuilder {
 /// [stream::unfold]: https://docs.rs/futures/latest/futures/stream/fn.unfold.html
 struct PaginatedState<T, U: PaginatedItemHandler<T>> {
     next_req: Option<Result<reqwest::Request>>,
-    client:   rest::Client,
-    handler:  Option<U>,
-    phantom:  PhantomData<T>,
+    client: rest::Client,
+    handler: Option<U>,
+    phantom: PhantomData<T>,
 }
 
 /// A builder to construct a paginated REST request.
 pub struct PaginatedRequestBuilder<T: PaginatedItem, U: PaginatedItemHandler<T> = ()> {
-    inner:   RequestBuilder,
+    inner: RequestBuilder,
     handler: Option<U>,
     phantom: PhantomData<T>,
 }
@@ -263,7 +263,7 @@ impl<T: PaginatedItem, U: PaginatedItemHandler<T>> PaginatedRequestBuilder<T, U>
 
 /// A Link HTTP header.
 struct Link {
-    rel:    String,
+    rel: String,
     params: String,
 }
 
@@ -298,7 +298,7 @@ impl TryFrom<&reqwest::header::HeaderValue> for Link {
             .ok_or_else(|| error!(40004, "Invalid Link header; missing params"))?;
 
         Ok(Self {
-            rel:    rel.as_str().to_string(),
+            rel: rel.as_str().to_string(),
             params: params.as_str().to_string(),
         })
     }
@@ -390,7 +390,7 @@ impl<T> PaginatedItem for T where T: DeserializeOwned + Send + 'static {}
 
 /// A page of items from a paginated response.
 pub struct PaginatedResult<T: PaginatedItem, U: PaginatedItemHandler<T> = ()> {
-    res:     Response,
+    res: Response,
     handler: Option<U>,
     phantom: PhantomData<T>,
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -63,7 +63,7 @@ pub struct ClientOptions {
     /// Encode requests using the binary msgpack encoding (true), or the JSON
     /// encoding (false). Defaults to true.
     pub(crate) use_binary_protocol: bool,
-    pub(crate) format:              rest::Format,
+    pub(crate) format: rest::Format,
 
     /// Query the Ably system for the current time when issuing tokens.
     /// Defaults to false.

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -15,10 +15,10 @@ use crate::{auth, crypto, history, http, json, presence, stats, Result};
 /// [Ably REST API]: https://ably.com/documentation/rest-api
 #[derive(Debug)]
 pub struct Rest {
-    pub auth:     auth::Auth,
+    pub auth: auth::Auth,
     pub channels: Channels,
-    pub client:   Client,
-    pub opts:     ClientOptions,
+    pub client: Client,
+    pub opts: ClientOptions,
 }
 
 impl Rest {
@@ -200,9 +200,9 @@ impl From<String> for Rest {
 /// send HTTP requests to the Ably REST API.
 pub struct Client {
     inner: reqwest::Client,
-    opts:  ClientOptions,
-    url:   reqwest::Url,
-    auth:  Option<Box<auth::Auth>>,
+    opts: ClientOptions,
+    url: reqwest::Url,
+    auth: Option<Box<auth::Auth>>,
 }
 
 impl Client {
@@ -372,7 +372,7 @@ impl From<CipherParams> for ChannelOptions {
 #[derive(Clone)]
 pub struct CipherParams {
     key: crypto::Key,
-    iv:  Option<crypto::IV>,
+    iv: Option<crypto::IV>,
 }
 
 impl CipherParams {
@@ -441,7 +441,7 @@ impl From<crypto::Key> for CipherParams {
 /// Start building a Channel to publish a message.
 pub struct ChannelBuilder {
     client: Client,
-    name:   String,
+    name: String,
     cipher: Option<CipherParams>,
 }
 
@@ -496,10 +496,10 @@ impl Channels {
 
 /// An Ably Channel to publish messages to or retrieve history or presence for.
 pub struct Channel {
-    pub name:     String,
+    pub name: String,
     pub presence: Presence,
-    client:       Client,
-    opts:         Option<ChannelOptions>,
+    client: Client,
+    opts: Option<ChannelOptions>,
 }
 
 impl Channel {
@@ -530,9 +530,9 @@ impl Channel {
 }
 
 pub struct Presence {
-    name:   String,
+    name: String,
     client: Client,
-    opts:   Option<ChannelOptions>,
+    opts: Option<ChannelOptions>,
 }
 
 impl Presence {
@@ -565,8 +565,8 @@ impl Presence {
 
 /// A request to publish a message to a channel.
 pub struct PublishBuilder {
-    req:    http::RequestBuilder,
-    msg:    Result<Message>,
+    req: http::RequestBuilder,
+    msg: Result<Message>,
     format: Format,
     cipher: Option<CipherParams>,
 }
@@ -786,19 +786,19 @@ impl Default for Encoding {
 #[derive(Default, Deserialize, Serialize)]
 pub struct Message {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id:            Option<String>,
+    pub id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name:          Option<String>,
+    pub name: Option<String>,
     #[serde(skip_serializing_if = "Data::is_none")]
-    pub data:          Data,
+    pub data: Data,
     #[serde(default, skip_serializing_if = "Encoding::is_none")]
-    pub encoding:      Encoding,
+    pub encoding: Encoding,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_id:     Option<String>,
+    pub client_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extras:        Option<json::Map>,
+    pub extras: Option<json::Map>,
 }
 
 impl Message {
@@ -868,13 +868,13 @@ impl Decode for Message {
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PresenceMessage {
-    pub action:        PresenceAction,
-    pub client_id:     String,
+    pub action: PresenceAction,
+    pub client_id: String,
     pub connection_id: String,
     #[serde(skip_serializing_if = "Data::is_none")]
-    pub data:          Data,
+    pub data: Data,
     #[serde(default, skip_serializing_if = "Encoding::is_none")]
-    pub encoding:      Encoding,
+    pub encoding: Encoding,
 }
 
 impl Decode for PresenceMessage {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -7,17 +7,17 @@ use serde::Deserialize;
 #[serde(default, rename_all = "camelCase")]
 pub struct Stats {
     pub interval_id: String,
-    pub unit:        Unit,
+    pub unit: Unit,
 
-    pub all:       Option<MessageTypes>,
-    pub inbound:   Option<MessageTraffic>,
-    pub outbound:  Option<MessageTraffic>,
+    pub all: Option<MessageTypes>,
+    pub inbound: Option<MessageTraffic>,
+    pub outbound: Option<MessageTraffic>,
     pub persisted: Option<MessageTypes>,
 
     pub connections: Option<ConnectionTypes>,
-    pub channels:    Option<ResourceCount>,
+    pub channels: Option<ResourceCount>,
 
-    pub api_requests:   Option<RequestCount>,
+    pub api_requests: Option<RequestCount>,
     pub token_requests: Option<RequestCount>,
 
     pub push: Option<Push>,
@@ -46,35 +46,35 @@ impl Default for Unit {
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct MessageCount {
-    pub count:   f64,
-    pub data:    f64,
-    pub failed:  f64,
+    pub count: f64,
+    pub data: f64,
+    pub failed: f64,
     pub refused: f64,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct ResourceCount {
-    pub peak:    f64,
-    pub min:     f64,
-    pub mean:    f64,
-    pub opened:  f64,
-    pub failed:  f64,
+    pub peak: f64,
+    pub min: f64,
+    pub mean: f64,
+    pub opened: f64,
+    pub failed: f64,
     pub refused: f64,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct RequestCount {
-    pub failed:    f64,
-    pub refused:   f64,
+    pub failed: f64,
+    pub refused: f64,
     pub succeeded: f64,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct MessageTypes {
-    pub all:      MessageCount,
+    pub all: MessageCount,
     pub messages: MessageCount,
     pub presence: MessageCount,
 }
@@ -82,62 +82,62 @@ pub struct MessageTypes {
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct ConnectionTypes {
-    pub all:   ResourceCount,
+    pub all: ResourceCount,
     pub plain: ResourceCount,
-    pub tls:   ResourceCount,
+    pub tls: ResourceCount,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct MessageTraffic {
-    pub all:            MessageTypes,
-    pub realtime:       MessageTypes,
-    pub rest:           MessageTypes,
-    pub webhook:        MessageTypes,
-    pub push:           MessageTypes,
+    pub all: MessageTypes,
+    pub realtime: MessageTypes,
+    pub rest: MessageTypes,
+    pub webhook: MessageTypes,
+    pub push: MessageTypes,
     pub external_queue: MessageTypes,
-    pub shared_queue:   MessageTypes,
-    pub http_event:     MessageTypes,
+    pub shared_queue: MessageTypes,
+    pub http_event: MessageTypes,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Push {
-    pub messages:         f64,
-    pub notifications:    PushNotifications,
+    pub messages: f64,
+    pub notifications: PushNotifications,
     pub direct_publishes: f64,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct PushNotifications {
-    pub invalid:    f64,
-    pub attempted:  PushTransportCount,
+    pub invalid: f64,
+    pub attempted: PushTransportCount,
     pub successful: PushTransportCount,
-    pub failed:     PushNotificationFailures,
+    pub failed: PushNotificationFailures,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct PushTransportCount {
     pub total: f64,
-    pub gcm:   f64,
-    pub fcm:   f64,
-    pub apns:  f64,
-    pub web:   f64,
+    pub gcm: f64,
+    pub fcm: f64,
+    pub apns: f64,
+    pub web: f64,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct PushNotificationFailures {
     pub retriable: PushTransportCount,
-    pub final_:    PushTransportCount,
+    pub final_: PushTransportCount,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct XchgMessages {
-    pub all:           MessageTypes,
+    pub all: MessageTypes,
     pub producer_paid: MessageDirections,
     pub consumer_paid: MessageDirections,
 }
@@ -145,23 +145,23 @@ pub struct XchgMessages {
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct MessageDirections {
-    pub all:      MessageTypes,
-    pub inbound:  MessageTraffic,
+    pub all: MessageTypes,
+    pub inbound: MessageTraffic,
     pub outbound: MessageTraffic,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Rates {
-    pub messages:       f64,
-    pub api_requests:   f64,
+    pub messages: f64,
+    pub api_requests: f64,
     pub token_requests: f64,
-    pub reactor:        ReactorRates,
+    pub reactor: ReactorRates,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct ReactorRates {
     pub http_event: f64,
-    pub amqp:       f64,
+    pub amqp: f64,
 }


### PR DESCRIPTION
The configured rustfmt options were nightly only which should be
avoided. Plus using the defaults most people use makes the code more in
line with other projets.