### PR TITLE
Refactor Auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ base64 = "0.13.0"
 block-modes = "0.9.1"
 cipher = "0.4.3"
 chrono = { version = "0.4.19", features = ["serde"] }
-dyn-clone = "1.0.5"
 futures = "0.3.21"
 hmac = "0.12.1"
 lazy_static = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,14 +35,14 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::auth::{AuthOptions, TokenParams, TokenSource};
+    use crate::auth::{AuthOptions, Credential, TokenParams};
     use crate::http::Method;
 
     #[test]
     fn rest_client_from_string_with_colon_sets_key() {
         let s = "appID.keyID:keySecret";
         let client = Rest::new(s).unwrap();
-        assert!(matches!(client.inner.opts.token, TokenSource::Key(_)));
+        assert!(matches!(client.inner.opts.credential, Credential::Key(_)));
     }
 
     #[test]
@@ -50,8 +50,8 @@ mod tests {
         let s = "appID.tokenID";
         let client = Rest::new(s).unwrap();
         assert!(matches!(
-            client.inner.opts.token,
-            TokenSource::TokenDetails(_)
+            client.inner.opts.credential,
+            Credential::TokenDetails(_)
         ));
     }
 
@@ -143,7 +143,7 @@ mod tests {
 
         fn auth_options(&self) -> AuthOptions {
             AuthOptions {
-                token: Some(self.options().token),
+                token: Some(self.options().credential),
                 headers: None,
                 method: Default::default(),
                 params: None,
@@ -326,7 +326,7 @@ mod tests {
         };
 
         let options = AuthOptions {
-            token: Some(client.options().token.clone()),
+            token: Some(client.options().credential.clone()),
             ..Default::default()
         };
 
@@ -400,7 +400,7 @@ mod tests {
         .unwrap();
 
         let options = AuthOptions {
-            token: Some(TokenSource::Url(auth_url)),
+            token: Some(Credential::Url(auth_url)),
             ..AuthOptions::default()
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,12 +54,12 @@ mod tests {
 
     #[test]
     fn client_options_errors_with_no_key_or_token() {
-        let err = ClientOptions::new().client().unwrap_err();
+        let err = ClientOptions::token_source().client().unwrap_err();
         assert_eq!(err.code, 40106);
     }
 
     fn test_client() -> Rest {
-        ClientOptions::new()
+        ClientOptions::token_source()
             .key("aaaaaa.bbbbbb:cccccc")
             .environment("sandbox")
             .client()
@@ -134,7 +134,9 @@ mod tests {
         }
 
         fn options(&self) -> ClientOptions {
-            ClientOptions::new().key(self.key()).environment("sandbox")
+            ClientOptions::token_source()
+                .key(self.key())
+                .environment("sandbox")
         }
 
         fn key(&self) -> auth::Key {
@@ -241,7 +243,7 @@ mod tests {
 
     #[tokio::test]
     async fn custom_request_with_bad_rest_host_returns_network_error() -> Result<()> {
-        let client = ClientOptions::new()
+        let client = ClientOptions::token_source()
             .key("aaaaaa.bbbbbb:cccccc")
             .rest_host("i-dont-exist.ably.com")
             .client()?;
@@ -776,7 +778,7 @@ mod tests {
     async fn client_fallback() -> Result<()> {
         // IANA reserved; requests to it will hang forever
         let unroutable_host = "10.255.255.1";
-        let client = ClientOptions::new()
+        let client = ClientOptions::token_source()
             .key("aaaaaa.bbbbbb:cccccc")
             .rest_host(unroutable_host)
             .fallback_hosts(vec!["sandbox-a-fallback.ably-realtime.com".to_string()])
@@ -802,7 +804,7 @@ mod tests {
         .unwrap();
 
         // Configure a client with an authUrl.
-        let client = ClientOptions::new()
+        let client = ClientOptions::token_source()
             .auth_url(auth_url)
             .environment("sandbox")
             .client()
@@ -824,7 +826,7 @@ mod tests {
         let app = Arc::new(TestApp::create().await?);
 
         // Configure a client with the test app as the authCallback.
-        let client = ClientOptions::new()
+        let client = ClientOptions::token_source()
             .auth_callback(app)
             .environment("sandbox")
             .client()
@@ -846,7 +848,7 @@ mod tests {
         let app = TestApp::create().await?;
 
         // Configure a client with a key and useTokenAuth=true.
-        let client = ClientOptions::new()
+        let client = ClientOptions::token_source()
             .key(app.key())
             .use_token_auth(true)
             .environment("sandbox")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,14 +41,14 @@ mod tests {
     fn rest_client_from_string_with_colon_sets_key() {
         let s = "appID.keyID:keySecret";
         let client = Rest::new(s).unwrap();
-        assert!(client.opts.key.is_some());
+        assert!(client.inner.opts.key.is_some());
     }
 
     #[test]
     fn rest_client_from_string_without_colon_sets_token_literal() {
         let s = "appID.tokenID";
         let client = Rest::new(s).unwrap();
-        assert!(client.opts.token.is_some());
+        assert!(client.inner.opts.token.is_some());
     }
 
     #[test]
@@ -334,7 +334,7 @@ mod tests {
             req.client_id.is_none(),
             "expected tokenRequest.client_id to not be set by default"
         );
-        assert_eq!(req.key_name, client.opts.key.unwrap().name);
+        assert_eq!(req.key_name, client.inner.opts.key.as_ref().unwrap().name);
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,22 +26,23 @@ pub use rest::{Data, Rest};
 mod tests {
     use std::collections::{HashMap, HashSet};
     use std::iter::FromIterator;
+    use std::sync::Arc;
 
-    use chrono::prelude::*;
-    use chrono::Duration;
+    use chrono::{Duration, Utc};
     use futures::TryStreamExt;
     use reqwest::Url;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
     use super::*;
+    use crate::auth::{AuthCallback, AuthOptions, TokenParams, TokenSource};
     use crate::http::Method;
 
     #[test]
     fn rest_client_from_string_with_colon_sets_key() {
         let s = "appID.keyID:keySecret";
         let client = Rest::new(s).unwrap();
-        assert!(client.inner.opts.key.is_some());
+        assert!(matches!(client.inner.opts.token, Some(TokenSource::Key(_))));
     }
 
     #[test]
@@ -53,9 +54,7 @@ mod tests {
 
     #[test]
     fn client_options_errors_with_no_key_or_token() {
-        let err = ClientOptions::new()
-            .client()
-            .expect_err("Expected 40106 error");
+        let err = ClientOptions::new().client().unwrap_err();
         assert_eq!(err.code, 40106);
     }
 
@@ -71,6 +70,18 @@ mod tests {
     #[derive(Clone, Debug, Deserialize)]
     struct TestApp {
         keys: Vec<auth::Key>,
+    }
+
+    impl auth::AuthCallback for TestApp {
+        fn token<'a>(
+            &'a self,
+            params: &'a TokenParams,
+        ) -> std::pin::Pin<
+            Box<dyn Send + futures::Future<Output = Result<auth::RequestOrDetails>> + 'a>,
+        > {
+            let fut = async { Ok(auth::RequestOrDetails::Request(self.token_request(params)?)) };
+            Box::pin(fut)
+        }
     }
 
     impl TestApp {
@@ -130,20 +141,17 @@ mod tests {
             self.keys[0].clone()
         }
 
-        async fn token_request(&self, params: auth::TokenParams) -> Result<auth::Token> {
-            let req = params.sign(&self.key())?;
-
-            Ok(auth::Token::Request(req))
+        fn token_request(&self, params: &auth::TokenParams) -> Result<auth::TokenRequest> {
+            self.key().sign(params)
         }
-    }
 
-    impl auth::AuthCallback for TestApp {
-        fn token<'a>(
-            &'a self,
-            _rest: &rest::Rest,
-            params: auth::TokenParams,
-        ) -> auth::TokenFuture<'a> {
-            Box::pin(self.token_request(params))
+        fn auth_options(&self) -> AuthOptions {
+            AuthOptions {
+                token: self.options().token,
+                headers: None,
+                method: Default::default(),
+                params: None,
+            }
         }
     }
 
@@ -255,21 +263,20 @@ mod tests {
         let app = TestApp::create().await?;
         let client = app.client();
 
-        // Create some stats for 3rd Feb last year.
-        let last_year = (Utc::today() - Duration::days(365)).year();
+        let year = 2010;
         let fixtures = json!([
             {
-                "intervalId": format!("{}-02-03:15:03", last_year),
+                "intervalId": format!("{}-02-03:15:03", year),
                 "inbound": { "realtime": { "messages": { "count": 50, "data": 5000 } } },
                 "outbound": { "realtime": { "messages": { "count": 20, "data": 2000 } } }
             },
             {
-                "intervalId": format!("{}-02-03:15:04", last_year),
+                "intervalId": format!("{}-02-03:15:04", year),
                 "inbound": { "realtime": { "messages": { "count": 60, "data": 6000 } } },
                 "outbound": { "realtime": { "messages": { "count": 10, "data": 1000 } } }
             },
             {
-                "intervalId": format!("{}-02-03:15:05", last_year),
+                "intervalId": format!("{}-02-03:15:05", year),
                 "inbound": { "realtime": { "messages": { "count": 70, "data": 7000 } } },
                 "outbound": { "realtime": { "messages": { "count": 40, "data": 4000 } } }
             }
@@ -284,8 +291,8 @@ mod tests {
         // Retrieve the stats.
         let res = client
             .stats()
-            .start(format!("{}-02-03:15:03", last_year).as_ref())
-            .end(format!("{}-02-03:15:05", last_year).as_ref())
+            .start(format!("{}-02-03:15:03", year).as_ref())
+            .end(format!("{}-02-03:15:05", year).as_ref())
             .forwards()
             .send()
             .await?;
@@ -312,76 +319,27 @@ mod tests {
     }
 
     #[test]
-    fn auth_create_token_request_no_options() -> Result<()> {
+    fn auth_create_token_request() -> Result<()> {
         let client = test_client();
 
-        let req = client.auth().create_token_request().sign()?;
+        let params = TokenParams {
+            capability: r#"{"*":["*"]}"#.to_string(),
+            client_id: Some("test@ably.com".to_string()),
+            nonce: None,
+            timestamp: None,
+            ttl: Duration::minutes(100),
+        };
 
-        assert!(
-            req.mac.unwrap().len() > 0,
-            "expected tokenRequest.mac to be set"
-        );
-        assert!(req.nonce.len() > 0, "expected tokenRequest.nonce to be set");
-        assert!(
-            req.ttl.is_none(),
-            "expected tokenRequest.ttl to not be set by default"
-        );
-        assert!(
-            req.capability.is_none(),
-            "expected tokenRequest.capability to not be set by default"
-        );
-        assert!(
-            req.client_id.is_none(),
-            "expected tokenRequest.client_id to not be set by default"
-        );
-        assert_eq!(req.key_name, client.inner.opts.key.as_ref().unwrap().name);
+        let options = AuthOptions {
+            token: client.options().token.clone(),
+            ..Default::default()
+        };
 
-        Ok(())
-    }
+        let req = client.auth().create_token_request(&params, &options)?;
 
-    #[test]
-    fn auth_create_token_request_with_capability() -> Result<()> {
-        let client = test_client();
-
-        let capability = r#"{"*":["*"]}"#;
-
-        let req = client
-            .auth()
-            .create_token_request()
-            .capability(capability)
-            .sign()?;
-
-        assert_eq!(req.capability, Some(capability.to_string()));
-
-        Ok(())
-    }
-
-    #[test]
-    fn auth_create_token_request_with_client_id() -> Result<()> {
-        let client = test_client();
-
-        let client_id = "test@ably.com";
-
-        let req = client
-            .auth()
-            .create_token_request()
-            .client_id(client_id)
-            .sign()?;
-
-        assert_eq!(req.client_id, Some(client_id.to_string()));
-
-        Ok(())
-    }
-
-    #[test]
-    fn auth_create_token_request_with_ttl() -> Result<()> {
-        let client = test_client();
-
-        let ttl = 60000;
-
-        let req = client.auth().create_token_request().ttl(ttl).sign()?;
-
-        assert_eq!(req.ttl, Some(ttl));
+        assert_eq!(req.capability, params.capability);
+        assert_eq!(req.client_id, params.client_id);
+        assert_eq!(req.ttl, params.ttl);
 
         Ok(())
     }
@@ -396,35 +354,37 @@ mod tests {
         let server_time = client.time().await?;
 
         // Request a token.
-        let token = client.auth().request_token().send().await?;
+        let token = client
+            .auth()
+            .request_token(&Default::default(), &app.auth_options())
+            .await?;
+        let meta = token.metadata.unwrap();
 
         // Check the token details.
         assert!(token.token.len() > 0, "Expected token to be set");
-        let issued = token.issued.expect("Expected issued to be set");
-        let expires = token.expires.expect("Expected expires to be set");
         assert!(
-            issued >= server_time,
+            meta.issued >= server_time,
             "Expected issued ({}) to be after server time ({})",
-            issued,
-            server_time
+            meta.issued,
+            server_time,
         );
         assert!(
-            expires > issued,
+            meta.expires > meta.issued,
             "Expected expires ({}) to be after issued ({})",
-            expires,
-            issued
+            meta.expires,
+            meta.issued
         );
-        let capability = token.capability.unwrap();
+        let capability = meta.capability;
         assert_eq!(
             capability, r#"{"*":["*"]}"#,
             r#"Expected default capability '{{"*":["*"]}}', got {}"#,
             capability
         );
         assert_eq!(
-            token.client_id,
+            meta.client_id,
             None,
             "Expected client_id to be null, got {}",
-            token.client_id.as_ref().unwrap()
+            meta.client_id.as_ref().unwrap()
         );
 
         Ok(())
@@ -444,12 +404,14 @@ mod tests {
         )
         .unwrap();
 
-        // Request a token from the authUrl.
+        let options = AuthOptions {
+            token: Some(TokenSource::Url(auth_url)),
+            ..AuthOptions::default()
+        };
+
         let token = client
             .auth()
-            .request_token()
-            .auth_url(auth_url)
-            .send()
+            .request_token(&Default::default(), &options)
             .await?;
 
         // Check the token details.
@@ -461,15 +423,12 @@ mod tests {
     #[tokio::test]
     async fn auth_request_token_with_provider() -> Result<()> {
         // Create a test app.
-        let app = TestApp::create().await?;
+        let app = Arc::new(TestApp::create().await?);
         let client = app.client();
 
-        // Request a token with a custom authCallback.
         let token = client
             .auth()
-            .request_token()
-            .auth_callback(app)
-            .send()
+            .request_token(&Default::default(), &app.auth_options())
             .await?;
 
         // Check the token details.
@@ -486,13 +445,23 @@ mod tests {
         // Create a client with client_id set in the options.
         let client_id = "test client id";
         let client = app.options().client_id(client_id).client()?;
+        let options = TokenParams {
+            client_id: Some(client_id.to_string()),
+            ..Default::default()
+        };
 
         // Request a token.
-        let token = client.auth().request_token().send().await?;
+        let token = client
+            .auth()
+            .request_token(&options, &app.auth_options())
+            .await?;
 
         // Check the token details include the client_id.
         assert!(token.token.len() > 0, "Expected token to be set");
-        assert_eq!(token.client_id, Some(client_id.to_string()));
+        assert_eq!(
+            token.metadata.unwrap().client_id,
+            Some(client_id.to_string())
+        );
 
         Ok(())
     }
@@ -852,7 +821,7 @@ mod tests {
     #[tokio::test]
     async fn rest_with_auth_callback() -> Result<()> {
         // Create a test app.
-        let app = TestApp::create().await?;
+        let app = Arc::new(TestApp::create().await?);
 
         // Configure a client with the test app as the authCallback.
         let client = ClientOptions::new()

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::auth::{AuthCallback, TokenSource};
+use crate::auth::{AuthCallback, Credential};
 use crate::error::*;
 use crate::{auth, http, rest, Result};
 
@@ -13,7 +13,7 @@ static REST_HOST: &str = "rest.ably.io";
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub struct ClientOptions {
-    pub(crate) token: auth::TokenSource,
+    pub(crate) credential: auth::Credential,
 
     /// The HTTP method to use when requesting a token from auth_url. Defaults
     /// to GET.
@@ -138,11 +138,11 @@ impl ClientOptions {
     }
 
     pub fn with_auth_url(url: reqwest::Url) -> Self {
-        Self::token_source(TokenSource::Url(url))
+        Self::token_source(Credential::Url(url))
     }
 
     pub fn with_auth_callback(callback: Arc<dyn AuthCallback>) -> Self {
-        Self::token_source(TokenSource::Callback(callback))
+        Self::token_source(Credential::Callback(callback))
     }
 
     /// Sets the API key.
@@ -156,11 +156,11 @@ impl ClientOptions {
     /// # }
     /// ```
     pub fn with_key(key: auth::Key) -> Self {
-        Self::token_source(TokenSource::Key(key))
+        Self::token_source(Credential::Key(key))
     }
 
     pub fn with_token(token: String) -> Self {
-        Self::token_source(TokenSource::TokenDetails(auth::TokenDetails::token(token)))
+        Self::token_source(Credential::TokenDetails(auth::TokenDetails::token(token)))
     }
 
     /// Set the client ID, used for identifying this client when publishing
@@ -342,9 +342,9 @@ impl ClientOptions {
         Ok(rest::Rest::create(http_client, self, rest_url))
     }
 
-    pub fn token_source(token: TokenSource) -> Self {
+    pub fn token_source(token: Credential) -> Self {
         Self {
-            token,
+            credential: token,
             auth_method: http::Method::GET,
             auth_headers: None,
             auth_params: None,

--- a/src/options.rs
+++ b/src/options.rs
@@ -318,9 +318,9 @@ impl ClientOptions {
     /// - the REST API URL must be valid
     ///
     /// [RSC1b]: https://docs.ably.io/client-lib-development-guide/features/#RSC1b
-    pub fn client(&self) -> Result<rest::Rest> {
-        if let Some(err) = &self.error {
-            return Err(err.clone());
+    pub fn client(self) -> Result<rest::Rest> {
+        if let Some(err) = self.error {
+            return Err(err);
         }
 
         let rest_url = if self.tls {
@@ -343,7 +343,7 @@ impl ClientOptions {
             .connect_timeout(self.http_open_timeout)
             .build()?;
 
-        Ok(rest::Rest::create(http_client, self.clone(), rest_url))
+        Ok(rest::Rest::create(http_client, self, rest_url))
     }
 
     pub fn token_source(token: TokenSource) -> Self {

--- a/src/options.rs
+++ b/src/options.rs
@@ -132,16 +132,16 @@ pub struct ClientOptions {
 impl ClientOptions {
     pub fn new(s: &str) -> Self {
         match auth::Key::new(s) {
-            Ok(k) => Self::key(k),
-            Err(_) => Self::token(s.to_string()),
+            Ok(k) => Self::with_key(k),
+            Err(_) => Self::with_token(s.to_string()),
         }
     }
 
-    pub fn auth_url(url: reqwest::Url) -> Self {
+    pub fn with_auth_url(url: reqwest::Url) -> Self {
         Self::token_source(TokenSource::Url(url))
     }
 
-    pub fn auth_callback(callback: Arc<dyn AuthCallback>) -> Self {
+    pub fn with_auth_callback(callback: Arc<dyn AuthCallback>) -> Self {
         Self::token_source(TokenSource::Callback(callback))
     }
 
@@ -157,11 +157,11 @@ impl ClientOptions {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn key(key: auth::Key) -> Self {
+    pub fn with_key(key: auth::Key) -> Self {
         Self::token_source(TokenSource::Key(key))
     }
 
-    pub fn token(token: String) -> Self {
+    pub fn with_token(token: String) -> Self {
         Self::token_source(TokenSource::TokenDetails(auth::TokenDetails::token(token)))
     }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -151,9 +151,7 @@ impl ClientOptions {
     ///
     /// ```
     /// # fn main() -> ably::Result<()> {
-    /// let client = ably::ClientOptions::new()
-    ///     .key("aaaaaa.bbbbbb:cccccc")
-    ///     .client()?;
+    /// let client = ably::ClientOptions::new("aaaaaa.bbbbbb:cccccc").client()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -196,8 +194,7 @@ impl ClientOptions {
     ///
     /// ```
     /// # fn main() -> ably::Result<()> {
-    /// let client = ably::ClientOptions::new()
-    ///     .key("aaaaaa.bbbbbb:cccccc")
+    /// let client = ably::ClientOptions::new("aaaaaa.bbbbbb:cccccc")
     ///     .environment("sandbox")
     ///     .client()?;
     /// # Ok(())
@@ -260,8 +257,7 @@ impl ClientOptions {
     ///
     /// ```
     /// # fn main() -> ably::Result<()> {
-    /// let client = ably::ClientOptions::new()
-    ///     .key("aaaaaa.bbbbbb:cccccc")
+    /// let client = ably::ClientOptions::new("aaaaaa.bbbbbb:cccccc")
     ///     .rest_host("sandbox-rest.ably.io")
     ///     .client()?;
     /// # Ok(())

--- a/src/options.rs
+++ b/src/options.rs
@@ -9,6 +9,7 @@ use crate::{auth, http, rest, Result};
 /// [Ably client options] for initialising a REST or Realtime client.
 ///
 /// [Ably client options]: https://ably.com/documentation/rest/types#client-options
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub struct ClientOptions {
     pub(crate) token: Option<auth::TokenSource>,
@@ -41,7 +42,6 @@ pub struct ClientOptions {
     /// Enable idempotent REST publishing. Defaults to false.
     ///
     /// See https://faqs.ably.com/what-is-idempotent-publishing
-    #[allow(dead_code)]
     pub(crate) idempotent_rest_publishing: bool,
 
     /// The list of fallback hosts to use in the case of an error necessitating
@@ -55,7 +55,6 @@ pub struct ClientOptions {
 
     /// Query the Ably system for the current time when issuing tokens.
     /// Defaults to false.
-    #[allow(dead_code)]
     pub(crate) query_time: bool,
 
     /// Override the default parameters used to request Ably tokens.
@@ -63,7 +62,6 @@ pub struct ClientOptions {
 
     /// Automatically connect when the Realtime library is instantiated.
     /// Defaults to true.
-    #[allow(dead_code)]
     pub(crate) auto_connect: bool,
 
     // pub queue_messages: bool,
@@ -74,31 +72,25 @@ pub struct ClientOptions {
 
     /// The hostname used in the Realtime API URL. Defaults to
     /// realtime.ably.io.
-    #[allow(dead_code)]
     pub(crate) realtime_host: String,
 
     /// The TCP port for non-TLS requests. Defaults to 80.
-    #[allow(dead_code)]
     pub(crate) port: u32,
 
     /// The TCP port for TLS requests. Defaults to 443.
-    #[allow(dead_code)]
     pub(crate) tls_port: u32,
 
     /// How long to wait before attempting to re-establish a connection which
     /// is in the DISCONNECTED state. Defaults to 15s.
-    #[allow(dead_code)]
     pub(crate) disconnected_retry_timeout: Duration,
 
     /// How long to wait before attempting to re-establish a connection which
     /// is in the SUSPENDED state. Defaults to 30s.
-    #[allow(dead_code)]
     pub(crate) suspended_retry_timeout: Duration,
 
     /// How long to wait before attempting to re-attach a channel which is in
     /// the SUSPENDED state following a server initiated detach. Defaults to
     /// 15s.
-    #[allow(dead_code)]
     pub(crate) channel_retry_timeout: Duration,
 
     /// How long to wait for a TCP connection to be established. Defaults to
@@ -115,27 +107,22 @@ pub struct ClientOptions {
 
     /// How long to wait for fallback requests to succeed before considering
     /// the request as failed. Defaults to 15s.
-    #[allow(dead_code)]
     pub(crate) http_max_retry_duration: Duration,
 
     /// The maximum size of messages that can be published in a single request.
     /// Defaults to 64KiB.
-    #[allow(dead_code)]
     pub(crate) max_message_size: u64,
 
     /// The maximum size of a single POST body or WebSocket frame. Defaults to
     /// 512KiB.
-    #[allow(dead_code)]
     pub(crate) max_frame_size: u64,
 
     /// How long to wait before switching back to the primary host after a
     /// successful request to a fallback endpoint. Defaults to 10m.
-    #[allow(dead_code)]
     pub(crate) fallback_retry_timeout: Duration,
 
     /// Include a random request_id in the query string of all API requests.
     /// Defaults to false.
-    #[allow(dead_code)]
     pub(crate) add_request_ids: bool,
 
     error: Option<ErrorInfo>,

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -45,7 +45,7 @@ impl Rest {
     }
 
     pub fn new(key: &str) -> Result<Self> {
-        ClientOptions::from(key).client()
+        ClientOptions::new(key).client()
     }
 
     pub(crate) fn create(reqwest: reqwest::Client, opts: ClientOptions, url: reqwest::Url) -> Self {
@@ -319,7 +319,7 @@ impl From<&str> for Rest {
     fn from(s: &str) -> Self {
         // unwrap the result since we're guaranteed to have a valid client when
         // it's initialised with an API key or token.
-        ClientOptions::from(s).client().unwrap()
+        ClientOptions::new(s).client().unwrap()
     }
 }
 

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -19,6 +19,7 @@ use crate::{history, http, json, presence, stats, Result};
 /// [Ably REST API]: https://ably.com/documentation/rest-api
 #[derive(Debug)]
 pub(crate) struct RestInner {
+    #[allow(dead_code)]
     pub channels: (),
     pub reqwest: reqwest::Client,
     pub opts: ClientOptions,

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::prelude::*;
 use lazy_static::lazy_static;
 use rand::seq::SliceRandom;
@@ -16,11 +18,16 @@ use crate::{history, http, json, presence, stats, Result};
 ///
 /// [Ably REST API]: https://ably.com/documentation/rest-api
 #[derive(Debug)]
-pub struct Rest {
+pub(crate) struct RestInner {
     pub channels: (),
     pub reqwest: reqwest::Client,
     pub opts: ClientOptions,
     pub url: reqwest::Url,
+}
+
+#[derive(Debug, Clone)]
+pub struct Rest {
+    pub(crate) inner: Arc<RestInner>,
 }
 
 impl Rest {
@@ -38,10 +45,12 @@ impl Rest {
 
     pub(crate) fn create(reqwest: reqwest::Client, opts: ClientOptions, url: reqwest::Url) -> Self {
         Self {
-            reqwest,
-            opts,
-            url,
-            channels: (),
+            inner: Arc::new(RestInner {
+                reqwest,
+                opts,
+                url,
+                channels: (),
+            }),
         }
     }
 
@@ -133,7 +142,7 @@ impl Rest {
     /// response is unsuccessful (i.e. the status code is not in the 200-299
     /// range).
     pub fn request(&self, method: http::Method, path: &str) -> http::RequestBuilder {
-        let mut url = self.url.clone();
+        let mut url = self.inner.url.clone();
         url.set_path(path);
         self.request_url(method, url)
     }
@@ -143,7 +152,11 @@ impl Rest {
         method: http::Method,
         url: impl reqwest::IntoUrl,
     ) -> http::RequestBuilder {
-        http::RequestBuilder::new(self, self.reqwest.request(method, url), self.opts.format)
+        http::RequestBuilder::new(
+            self,
+            self.inner.reqwest.request(method, url),
+            self.inner.opts.format,
+        )
     }
 
     /// Start building a paginated HTTP request to the Ably REST API.
@@ -211,7 +224,7 @@ impl Rest {
         }
 
         // Create a randomised list of fallback hosts if they're set.
-        let mut hosts = match &self.opts.fallback_hosts {
+        let mut hosts = match &self.inner.opts.fallback_hosts {
             None => return Err(err),
             Some(hosts) => hosts.clone(),
         };
@@ -219,7 +232,7 @@ impl Rest {
 
         // Try sending the request to the fallback hosts, capped at
         // ClientOptions.httpMaxRetryCount.
-        for host in hosts.iter().take(self.opts.http_max_retry_count) {
+        for host in hosts.iter().take(self.inner.opts.http_max_retry_count) {
             // Check we have a next request to send.
             let mut req = match next_req {
                 Some(req) => req,
@@ -256,7 +269,7 @@ impl Rest {
             self.auth().with_auth_headers(&mut req).await?;
         }
 
-        let res = self.reqwest.execute(req).await?;
+        let res = self.inner.reqwest.execute(req).await?;
 
         // Return the response if it was successful, otherwise try to decode a
         // JSON error from the response body, falling back to a generic error
@@ -457,7 +470,7 @@ impl<'a> PublishBuilder<'a> {
         Self {
             req,
             msg: Ok(Message::default()),
-            format: rest.opts.format,
+            format: rest.inner.opts.format,
             cipher: None,
         }
     }

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -39,6 +39,10 @@ impl Rest {
         Channels { rest: self }
     }
 
+    pub fn options(&self) -> &ClientOptions {
+        &self.inner.opts
+    }
+
     pub fn new(key: &str) -> Result<Self> {
         ClientOptions::from(key).client()
     }
@@ -106,7 +110,7 @@ impl Rest {
             .pop()
             .ok_or_else(|| error!(40000, "Invalid response from /time"))?;
 
-        Ok(Utc.timestamp(time / 1000, time as u32 % 1000))
+        Ok(Utc.timestamp_millis(time))
     }
 
     /// Start building a HTTP request to the Ably REST API.


### PR DESCRIPTION
This is rather huge and I wish it was split more commits but most of the
code didnt compile through this process.

This makes AuthParms and AuthOptions direct arguments to the auth
functions, doing away with the builder functions. Having a separate
builder type for both functions, and each having functions to set all
the auth options/parms options seemed quite a bit overkill. Especially
as the user may wish to save these structs for reuse. I also found it
a bit confusing personally.

I've also tweaked what is and isn't an option. This is surely not 100%
correct and the spec is not the best at laying this out so I'm sure more
work will be needed.

This also combines things that can't be set at the same time into enums.
For auth at anyway, this still needs to be done for client options.