### PR TITLE
Implement ability to get existing channels and set their options

### DIFF
--- a/examples/history.rs
+++ b/examples/history.rs
@@ -10,20 +10,21 @@ async fn main() -> Result<()> {
 
     let client = ably::Rest::new(&key)?;
 
-    let channel = client.channels().get("rust-example");
+    let channel = client.channels().get("rust-example").await;
 
     // Publish 10 messages
     for n in 1..11 {
         println!("Publishing message {}", n);
         channel
             .publish()
+            .await
             .string(format!("message {}", n))
             .send()
             .await?;
     }
 
     // Retrieve the history
-    let mut pages = channel.history().pages();
+    let mut pages = channel.history().await.pages();
     while let Some(Ok(page)) = pages.next().await {
         let msgs = page.items().await?;
         println!("Received page of {} messages", msgs.len());

--- a/examples/publish.rs
+++ b/examples/publish.rs
@@ -10,11 +10,12 @@ async fn main() -> Result<()> {
 
     let client = ably::Rest::new(&key)?;
 
-    let channel = client.channels().get("rust-example");
+    let channel = client.channels().get("rust-example").await;
 
     println!("Publishing a string");
     match channel
         .publish()
+        .await
         .name("string")
         .string("a string")
         .send()
@@ -31,14 +32,28 @@ async fn main() -> Result<()> {
         y: i32,
     }
     let point = Point { x: 3, y: 4 };
-    match channel.publish().name("json").json(point).send().await {
+    match channel
+        .publish()
+        .await
+        .name("json")
+        .json(point)
+        .send()
+        .await
+    {
         Ok(_) => println!("JSON object published!"),
         Err(err) => println!("Error publishing message: {}", err),
     }
 
     println!("Publishing binary data");
     let data = vec![0x01, 0x02, 0x03, 0x04];
-    match channel.publish().name("binary").binary(data).send().await {
+    match channel
+        .publish()
+        .await
+        .name("binary")
+        .binary(data)
+        .send()
+        .await
+    {
         Ok(_) => println!("Binary data published!"),
         Err(err) => println!("Error publishing message: {}", err),
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,0 +1,130 @@
+use crate::crypto::CipherParams;
+use crate::http::{self, PaginatedRequestBuilder};
+use crate::presence::Presence;
+use crate::rest::{Message, PublishBuilder};
+use crate::Rest;
+
+/// Options for publishing messages on a channel.
+#[derive(Clone, Debug)]
+pub struct ChannelOptions {
+    pub(crate) cipher: Option<CipherParams>,
+}
+
+impl ChannelOptions {
+    pub fn from_cipher(cipher: CipherParams) -> Self {
+        Self {
+            cipher: Some(cipher),
+        }
+    }
+}
+
+/// A collection of Channels.
+#[derive(Clone, Debug)]
+pub struct Channels {
+    rest: Rest,
+}
+
+impl Channels {
+    pub(crate) fn new(rest: Rest) -> Self {
+        Self { rest }
+    }
+
+    pub fn rest(&self) -> &Rest {
+        &self.rest
+    }
+
+    pub async fn get(&self, name: impl Into<String>) -> Channel {
+        self.get_with_options(name, None).await
+    }
+
+    /// Build and return a Channel with the given name.
+    pub async fn get_with_options(
+        &self,
+        name: impl Into<String>,
+        options: Option<ChannelOptions>,
+    ) -> Channel {
+        let name = name.into();
+        self.rest()
+            .inner
+            .channels
+            .lock()
+            .await
+            .entry(name.clone())
+            .or_insert(InnerChannel { options });
+        Channel {
+            channels: self.clone(),
+            name,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct InnerChannel {
+    // maybe this should be it's own Arc<Mutex<T>>. This would mean we don't need to lock the main
+    // channels vec whenever we read channel options. But it would mean we have 2 levels of locks
+    // and allocations.
+    pub options: Option<ChannelOptions>,
+}
+
+/// An Ably Channel to publish messages to or retrieve history or presence for.
+#[derive(Clone, Debug)]
+pub struct Channel {
+    pub channels: Channels,
+    pub name: String,
+}
+
+impl Channel {
+    pub fn rest(&self) -> &Rest {
+        self.channels().rest()
+    }
+
+    pub fn channels(&self) -> &Channels {
+        &self.channels
+    }
+
+    pub async fn set_options(&self, options: Option<ChannelOptions>) {
+        if let Some(channel) = self.rest().inner.channels.lock().await.get_mut(&self.name) {
+            channel.options = options;
+        }
+    }
+
+    pub async fn options(&self) -> Option<ChannelOptions> {
+        // TODO maybe error when missing options instead of returning none
+        self.rest()
+            .inner
+            .channels
+            .lock()
+            .await
+            .get(&self.name)
+            .and_then(|c| c.options.clone())
+    }
+
+    pub fn presence(&self) -> Presence {
+        Presence::new(self.rest().clone(), self.name.clone())
+    }
+
+    /// Start building a request to publish a message on the channel.
+    pub async fn publish(&self) -> PublishBuilder {
+        let mut builder = PublishBuilder::new(self.rest(), self.name.clone());
+
+        if let Some(opts) = self.options().await {
+            if let Some(cipher) = &opts.cipher {
+                builder = builder.cipher(cipher.clone());
+            }
+        }
+
+        builder
+    }
+
+    /// Start building a history request for the channel.
+    ///
+    /// Returns a history::RequestBuilder which is used to set parameters
+    /// before sending the history request.
+    pub async fn history(&self) -> PaginatedRequestBuilder<Message> {
+        self.rest().paginated_request_with_options(
+            http::Method::GET,
+            &format!("/channels/{}/history", self.name),
+            self.options().await,
+        )
+    }
+}

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -262,6 +262,7 @@ mod tests {
     use serde::Deserialize;
 
     use super::*;
+    use crate::channel;
     use crate::{json, rest};
 
     #[test]
@@ -297,8 +298,8 @@ mod tests {
                 .unwrap_or_else(|_| panic!("Expected JSON data in {}", name))
         }
 
-        fn opts(&self) -> rest::ChannelOptions {
-            rest::ChannelOptions {
+        fn opts(&self) -> channel::ChannelOptions {
+            channel::ChannelOptions {
                 cipher: Some(
                     CipherParams::builder()
                         .string(&self.key)

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -1,14 +1,19 @@
 use futures::stream::Stream;
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::{http, rest, Result};
+use crate::channel::ChannelOptions;
+use crate::rest::{Encoding, Rest};
+use crate::Result;
+use crate::{http, Data};
 
 /// A type alias for a PaginatedRequestBuilder which uses a MessageItemHandler
 /// to handle pages of presence messages returned from a presence request.
-pub type PaginatedRequestBuilder<'a> = http::PaginatedRequestBuilder<'a, rest::PresenceMessage>;
+pub type PaginatedRequestBuilder<'a> = http::PaginatedRequestBuilder<'a, PresenceMessage>;
 
 /// A type alias for a PaginatedResult which uses a MessageItemHandler to
 /// handle pages of presence messages returned from a presence request.
-pub type PaginatedResult = http::PaginatedResult<rest::PresenceMessage>;
+pub type PaginatedResult = http::PaginatedResult<PresenceMessage>;
 
 /// A builder to construct a REST presence request.
 pub struct RequestBuilder<'a> {
@@ -49,4 +54,72 @@ impl<'a> RequestBuilder<'a> {
     pub async fn send(self) -> Result<PaginatedResult> {
         self.inner.send().await
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct Presence {
+    rest: Rest,
+    name: String,
+}
+
+impl Presence {
+    pub(crate) fn new(rest: Rest, name: String) -> Self {
+        Self { rest, name }
+    }
+
+    /// Start building a presence request for the channel.
+    pub async fn get(&self) -> RequestBuilder {
+        let req = self.rest.paginated_request_with_options(
+            http::Method::GET,
+            &format!("/channels/{}/presence", self.name),
+            self.options().await,
+        );
+        RequestBuilder::new(req)
+    }
+
+    /// Start building a presence history request for the channel.
+    ///
+    /// Returns a history::RequestBuilder which is used to set parameters
+    /// before sending the history request.
+    pub async fn history(&self) -> crate::http::PaginatedRequestBuilder<PresenceMessage> {
+        self.rest.paginated_request_with_options(
+            http::Method::GET,
+            &format!("/channels/{}/presence/history", self.name),
+            self.options().await,
+        )
+    }
+
+    pub async fn options(&self) -> Option<ChannelOptions> {
+        // TODO maybe error when missing options instead of returning none
+        self.rest
+            .inner
+            .channels
+            .lock()
+            .await
+            .get(&self.name)
+            .and_then(|c| c.options.clone())
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PresenceMessage {
+    pub action: PresenceAction,
+    pub client_id: String,
+    pub connection_id: String,
+    #[serde(skip_serializing_if = "Data::is_none")]
+    pub data: Data,
+    #[serde(default, skip_serializing_if = "Encoding::is_none")]
+    pub encoding: Encoding,
+}
+
+#[derive(Clone, Debug, Deserialize_repr, PartialEq, Eq, Serialize_repr)]
+#[serde(untagged)]
+#[repr(u8)]
+pub enum PresenceAction {
+    Absent,
+    Present,
+    Enter,
+    Leave,
+    Update,
 }


### PR DESCRIPTION
While there was already the ability to create channels via the get method, channels were never actually stored anywhere and recalled again when get was called a second time as the spec demands.

This introduces mutability into the REST SDK for the first time. The way I've choosen to implement it here is to have a Vec of channels inside the rest struct protected by a mutex. The channels themselves are actually just names and look up the mutex'd list any time the options are needed. This allows the settings to be upated at any time and the updates to apply to existing channels.

This method does mean that the channel list needs to be locked on every options access. This could be fixed by making each options instance it's own mutex and arc but I don't think that's needed. Especially as there's no way for a user to hold on to a mutex lock.

There's also the question of what happens if you release a channel then try and publish/get options of that channel. The spec doesn't say anything about this so for now it just uses the default options.

I've also removed the channel builder for now as there's only 2 arguments for a channel, maybe even one if we remove the with_options function as the spec is unclear on if it should still be implemented.