### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,13 +16,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: 'recursive'
           persist-credentials: false
 
       - name: Setup Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           profile: minimal
           toolchain: stable
@@ -31,12 +31,12 @@ jobs:
         run: rustc -V
 
       - name: cargo check
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           command: check
 
       - name: cargo test
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           command: test
 
@@ -44,7 +44,7 @@ jobs:
         run: rustup component add rustfmt
 
       - name: cargo fmt
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           command: fmt
           args: --all -- --check
@@ -53,7 +53,7 @@ jobs:
         run: rustup component add clippy
 
       - name: cargo clippy
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,10 +6,14 @@ on:
 
 name: Check
 
+permissions: {}
+
 jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Setup Rust Toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       deployments: write
       id-token: write
-    uses: ably/features/.github/workflows/sdk-features.yml@main
+    uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main
     with:
       repository-name: ably-rust
     secrets:

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -17,4 +17,5 @@ jobs:
     uses: ably/features/.github/workflows/sdk-features.yml@main
     with:
       repository-name: ably-rust
-    secrets: inherit
+    secrets:
+      ABLY_AWS_ACCOUNT_ID_SDK: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -6,8 +6,14 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   build:
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
     uses: ably/features/.github/workflows/sdk-features.yml@main
     with:
       repository-name: ably-rust


### PR DESCRIPTION
  Routine hygiene pass over the GitHub Actions workflows in this repo, addressing findings from a workflow security audit. Changes are split into four commits, one per finding type:

  - Disable credential persistence on actions/checkout so the default GITHUB_TOKEN is not left in the local git config after checkout.
  - Scope workflow and job permissions explicitly: top-level permissions: {} on each workflow, with each job granted only the GITHUB_TOKEN scopes it actually needs (contents: read for the
   check job; contents: read plus the deployments: write / id-token: write that the called reusable workflow declares it needs).
  - Replace secrets: inherit in the Features workflow with an explicit pass-through of just ABLY_AWS_ACCOUNT_ID_SDK — the only secret the called reusable workflow declares as required —
  so unrelated secrets are not forwarded.
  - Pin all third-party actions and the reusable workflow reference to full commit SHAs (with the original @v1 / @v2 / @main ref preserved as a trailing comment) so an upstream tag or
  branch move can't silently change what runs in CI.